### PR TITLE
LG-1299 Get rid of radio buttons for IAL1 and IAL2

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,6 @@
 class HomeController < ApplicationController
   def index
+    @omniauth_request_url = build_omniauth_request_url
     session[:agency] = params[:agency]
     render_agency
   end
@@ -13,6 +14,21 @@ class HomeController < ApplicationController
   end
 
   private
+
+  def build_omniauth_request_url
+    uri = URI.parse('/auth/saml')
+    uri.query = { ial: ial }.to_query
+    uri.to_s
+  end
+
+  def ial
+    case params[:ial].to_i
+    when 2
+      2
+    else
+      1
+    end
+  end
 
   def render_agency
     return unless current_agency

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,18 +1,7 @@
 <div class="container py2">
   <div class="mb1 right-align">
-    <% is_ial_2 = params[:ial] == '2' %>
-    <%= form_tag('auth/saml', method: :get) do %>
-      <div class="mb1">
-        <%= label_tag 'ial_1' do %>
-          <%= radio_button_tag 'ial', '1', !is_ial_2 %> IAL1
-        <% end %>
-        <%= label_tag 'ial_2' do %>
-          <%= radio_button_tag 'ial', '2', is_ial_2 %> IAL2
-        <% end %>
-      </div>
-      <button type="submit" class="btn btn-outline bg-white navy">
-        <%= image_tag 'login-gov.svg', class: "align-middle", width:"125" %>
-      </button>
+    <%= link_to @omniauth_request_url, class: "btn btn-outline bg-white navy" do %>
+      <%= image_tag 'login-gov.svg', class: "align-middle", width:"125" %>
     <% end %>
   </div>
   <div class="clearfix py2 mxn1">

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -1,10 +1,36 @@
 require 'rails_helper'
 
 RSpec.describe HomeController, type: :controller do
+  render_views
+
   describe 'GET #index' do
     it 'returns http success' do
       get :index
       expect(response).to have_http_status(:success)
+    end
+
+    context 'with the ial param set to 1' do
+      it 'renders a link for an ial 1 sign in' do
+        get :index, params: { ial: '1' }
+
+        expect(response.body).to include('/auth/saml?ial=1')
+      end
+    end
+
+    context 'with the ial param set to 2' do
+      it 'renders a link for an ial 1 sign in' do
+        get :index, params: { ial: '2' }
+
+        expect(response.body).to include('/auth/saml?ial=2')
+      end
+    end
+
+    context 'with the ial param nil' do
+      it 'renders a link for an ial 1 sign in' do
+        get :index, params: { ial: '1' }
+
+        expect(response.body).to include('/auth/saml?ial=1')
+      end
     end
   end
 end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe HomeController, type: :controller do
     end
 
     context 'with the ial param set to 2' do
-      it 'renders a link for an ial 1 sign in' do
+      it 'renders a link for an ial 2 sign in' do
         get :index, params: { ial: '2' }
 
         expect(response.body).to include('/auth/saml?ial=2')


### PR DESCRIPTION
**Why**: This is part of the process for re-designing this example SP for demos. Whether the login is IAL1 or IAL2 can be controlled with a query param on the home screen.