### PR TITLE
LG-1457: correct the dev idp_cert_fingerprint

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -15,7 +15,7 @@ development:
   saml_issuer: urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost-rails
   idp_sso_url: http://localhost:3000/api/saml/auth
   idp_slo_url: http://localhost:3000/api/saml/logout
-  idp_cert_fingerprint: '8B:D5:C2:E8:9A:2B:CE:B7:4B:95:50:BA:16:79:05:27:17:D1:D3:67'
+  idp_cert_fingerprint: 'BD:21:A9:57:14:3C:A8:4F:3F:C5:E6:99:7F:97:F6:E4:7E:E7:1D:1F'
   acs_url: http://localhost:3003/auth/saml/callback
 
 test:


### PR DESCRIPTION
Amos and I discovered that the idp_cert_fingerprint in the development env did not match the cert in the idp.