### PR TITLE
LG-1814: show logout on mobile

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -47,7 +47,7 @@
               <div class="sign-in-wrap">
                 <div class="center p1"><%= current_user.email %></div>
                 <div>
-                <form action="/auth/saml/logout" method="POST" class="center sm-show">
+                <form action="/auth/saml/logout" method="POST" class="center">
                   <button type="submit" class="btn p0">Log out</button>
                 </form>
                 </div>


### PR DESCRIPTION
Removed an unnecessary class that caused the logout link to not be displayed in mobile.