### PR TITLE
LG-1414 Use the correct email when signing in with multi-email user

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -94,7 +94,7 @@ Layout/DotPosition:
   - leading
   - trailing
 
-Style/FileName:
+Naming:
   Exclude:
     - Capfile
 
@@ -108,7 +108,6 @@ Style/IfUnlessModifier:
   Description: Favor modifier if/unless usage when you have a single-line body.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier
   Enabled: true
-  MaxLineLength: 100
 
 Style/PercentLiteralDelimiters:
   # Specify the default preferred delimiter for all types with the 'default' key

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,10 @@
 class User < ActiveRecord::Base
   def self.from_omniauth(auth)
-    where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
+    current_user = where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
       user.assign_from_auth(auth)
     end
+    current_user.sync_auth_email(auth.info.email)
+    current_user
   end
 
   def assign_from_auth(auth)
@@ -10,6 +12,10 @@ class User < ActiveRecord::Base
 
     assign_attrs(auth.info)
     extra_attributes_from_auth(auth) if auth.extra
+  end
+
+  def sync_auth_email(email)
+    update(email: email) unless self.email == email
   end
 
   private

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,27 +17,54 @@ RSpec.describe User, type: :model do
         @user.save!
       end
 
-      it 'finds a user if they exist and leaves the email, names alone' do
-        auth = OmniAuth::AuthHash.new(provider: 'test_provider',
-                                      uid: 'test_uid',
-                                      info: {
-                                        email: 'email@example.com',
-                                        first_name: 'Name',
-                                        last_name: 'McNameface'
-                                      },
-                                      extra: {
-                                        raw_info: {
-                                          ssn: '123456789',
-                                          phone: '4155551212'
-                                        }
-                                      })
-        user = nil
-        expect { user = User.from_omniauth(auth) }.to change { User.all.count }.by(0)
-        expect(user.email).to eq(@user.email)
-        expect(user.first_name).to eq(@user.first_name)
-        expect(user.last_name).to eq(@user.last_name)
-        expect(user.phone).to eq(@user.phone)
-        expect(user.social_security_number).to eq(@user.social_security_number)
+      context 'when the found user has the same email as the one from omniauth' do
+        it 'finds the user and leaves the user info alone' do
+          auth = OmniAuth::AuthHash.new(provider: 'test_provider',
+                                        uid: 'test_uid',
+                                        info: {
+                                          email: 'email@example.com',
+                                          first_name: 'Name',
+                                          last_name: 'McNameface'
+                                        },
+                                        extra: {
+                                          raw_info: {
+                                            ssn: '123456789',
+                                            phone: '4155551212'
+                                          }
+                                        })
+          user = nil
+          expect { user = User.from_omniauth(auth) }.to change { User.all.count }.by(0)
+          expect(user.email).to eq(@user.email)
+          expect(user.first_name).to eq(@user.first_name)
+          expect(user.last_name).to eq(@user.last_name)
+          expect(user.phone).to eq(@user.phone)
+          expect(user.social_security_number).to eq(@user.social_security_number)
+        end
+      end
+
+      context 'when the found user has a different email as the one from omniauth' do
+        it 'finds the user and updates the email' do
+          auth = OmniAuth::AuthHash.new(provider: 'test_provider',
+                                        uid: 'test_uid',
+                                        info: {
+                                          email: 'a_different_email@example.com',
+                                          first_name: 'Name',
+                                          last_name: 'McNameface'
+                                        },
+                                        extra: {
+                                          raw_info: {
+                                            ssn: '123456789',
+                                            phone: '4155551212'
+                                          }
+                                        })
+          user = nil
+          expect { user = User.from_omniauth(auth) }.to change { User.all.count }.by(0)
+          expect(user.email).to eq(auth.info.email)
+          expect(user.first_name).to eq(@user.first_name)
+          expect(user.last_name).to eq(@user.last_name)
+          expect(user.phone).to eq(@user.phone)
+          expect(user.social_security_number).to eq(@user.social_security_number)
+        end
       end
     end
 


### PR DESCRIPTION
**Why:** So that a user of the IdP with multiple email addresses can log into the SAML rails sample app and see the email address that they logged in with.  
